### PR TITLE
Use RawConfigParser for Python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,15 @@ from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
 from distutils import config
-conf = config.ConfigParser()
+
+#The same a dirty hack to get around some early import/configurations ambiguities
+if sys.version_info[0] >= 3:
+    # Python3
+    conf = config.RawConfigParser()
+else:
+    # Python2
+    conf = config.ConfigParser()
+
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 


### PR DESCRIPTION
With Python3, the `distutils.config` no longer contains `ConfigParser`, but it does contain `RawConfigParser`.

When using `python setup.py install` in the `/home/user//github/image_registration/` directory, I received the following AttributeError:

```
Traceback (most recent call last):
  File "setup.py", line 29, in <module>
    conf = config.ConfigParser()
AttributeError: module 'distutils.config' has no attribute 'ConfigParser'
```

Changing line 25 of `setup.py` from `conf = config.ConfigParser` to 

```
if sys.version_info[0] >= 3:
    # Python3
    conf = config.RawConfigParser()
else:
    # Python2
    conf = config.ConfigParser()
```

fixes this issue. 

I am **not** sure if `RawConfigParser` has the same robustness as `ConfigParser`, but it solves this issue.
