### PR TITLE
matplotlib.docstring deprecated from >=3.6

### DIFF
--- a/image_registration/fft_tools/zoom.py
+++ b/image_registration/fft_tools/zoom.py
@@ -1,7 +1,6 @@
 from . import fast_ffts
 import numpy as np
 from . import scale
-from matplotlib import docstring
 
 def zoom1d(inp, usfac=1, outsize=None, offset=0, nthreads=1,
         use_numpy_fft=False, return_xouts=False, return_real=True):


### PR DESCRIPTION
See https://matplotlib.org/3.6.3/api/docstring_api.html
Seems to be unused.

closes #51