### PR TITLE
Fix links to PDF and jupyter notebook in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,9 +57,9 @@ Module APIs:
    :obj:`~image_registration.chi2_shifts.chi2_shift`
 
    There is an ipython notebook demonstration of the code `here
-   <http://nbviewer.ipython.org/urls/raw.github.com/keflavich/image_registration/master/examples/Cross%2520Correlation.ipynb>`__
+   <https://nbviewer.org/github/keflavich/image_registration/blob/master/examples/Cross%20Correlation.ipynb>`__
    and in pdf `here
-   <https://github.com/keflavich/image_registration/blob/master/doc/CrossCorrelationSimulation.pdf?raw=true>`__
+   <https://github.com/keflavich/image_registration/blob/master/docs/CrossCorrelationSimulation.pdf?raw=true>`__
 
 Related Methods
 ---------------


### PR DESCRIPTION
I've updated the links to conform with the `doc/` -> `docs/` change, and fixed the nbviewer link :)