### PR TITLE
adjust to be compatable with depricated numpy syntax (re. shiftnd crash)

### DIFF
--- a/image_registration/fft_tools/shift.py
+++ b/image_registration/fft_tools/shift.py
@@ -98,13 +98,13 @@ def shiftnd(data, offset, phase=0, nthreads=1, use_numpy_fft=False,
         data = np.nan_to_num(data)
 
     freq_grid = sum(
-        np.array([off*np.fft.fftfreq(nx)[
+            [off*np.fft.fftfreq(nx)[
             tuple(
                 [np.newaxis]*dim + [slice(None)] + [np.newaxis]*(data.ndim-dim-1)
                 )
             ]
-            for dim,(off,nx) in enumerate(zip(offset,data.shape))],
-        )
+            for dim,(off,nx) in enumerate(zip(offset,data.shape))]
+    )
 
     kernel = np.exp(-1j*2*np.pi*freq_grid-1j*phase)
 

--- a/image_registration/fft_tools/shift.py
+++ b/image_registration/fft_tools/shift.py
@@ -98,12 +98,12 @@ def shiftnd(data, offset, phase=0, nthreads=1, use_numpy_fft=False,
         data = np.nan_to_num(data)
 
     freq_grid = np.sum(
-        [off*np.fft.fftfreq(nx)[
+        np.array([off*np.fft.fftfreq(nx)[
             tuple(
                 [np.newaxis]*dim + [slice(None)] + [np.newaxis]*(data.ndim-dim-1)
                 )
             ]
-            for dim,(off,nx) in enumerate(zip(offset,data.shape))],
+            for dim,(off,nx) in enumerate(zip(offset,data.shape))],dtype=object),
         axis=0)
 
     kernel = np.exp(-1j*2*np.pi*freq_grid-1j*phase)

--- a/image_registration/fft_tools/shift.py
+++ b/image_registration/fft_tools/shift.py
@@ -97,14 +97,14 @@ def shiftnd(data, offset, phase=0, nthreads=1, use_numpy_fft=False,
     if np.any(np.isnan(data)):
         data = np.nan_to_num(data)
 
-    freq_grid = np.sum(
+    freq_grid = sum(
         np.array([off*np.fft.fftfreq(nx)[
             tuple(
                 [np.newaxis]*dim + [slice(None)] + [np.newaxis]*(data.ndim-dim-1)
                 )
             ]
-            for dim,(off,nx) in enumerate(zip(offset,data.shape))],dtype=object),
-        axis=0)
+            for dim,(off,nx) in enumerate(zip(offset,data.shape))],
+        )
 
     kernel = np.exp(-1j*2*np.pi*freq_grid-1j*phase)
 


### PR DESCRIPTION
starting from numpy 1.24.0 ragged array are deprecated. previous usage in `shiftnd` is not compatible any more.
see https://github.com/numpy/numpy/pull/22004

Note: perhaps the requirements should be updated to numpy>=1.24.0

closes #55 